### PR TITLE
Refactor build structure and enhance work essence support

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -7,7 +7,7 @@ export default {
     [
       '@semantic-release/github',
       {
-        assets: ['src/*/dist/*.user.js'],
+        assets: ['dist/*/*.user.js'],
       },
     ],
   ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig(
     external: defineExternal(['@violentmonkey/ui', '@violentmonkey/dom', 'solid-js', 'solid-js/web']),
     output: {
       format: 'iife',
-      file: `src/${name}/dist/${name}.user.js`,
+      file: `dist/${name}/${name}.user.js`,
       globals: {
         'solid-js': 'VM.solid',
         'solid-js/web': 'VM.solid.web',

--- a/src/acum-work-import/acum.ts
+++ b/src/acum-work-import/acum.ts
@@ -118,8 +118,10 @@ export function searchName(name: string) {
 }
 
 export enum EssenceType {
-  NoLyrics = '15',
-  Song = '30',
+  LightMusicNoWords = '15', // Light music (without words)
+  Song = '30', // Popular song
+  Jazz = '40', // Original jazz work
+  ChoirSong = '53', // Original song for 4 part choir
   /** @knipignore */
   Unknown = '-1',
 }

--- a/src/acum-work-import/ui/work-edit-data.tsx
+++ b/src/acum-work-import/ui/work-edit-data.tsx
@@ -61,17 +61,18 @@ export async function udpateEditData(workState: WorkStateWithEditDataT, track: W
   workState.editData = {
     name: track.workHebName,
     comment: workState.originalEditData.comment,
-    type_id:
-      essenceType(track) == EssenceType.Song
-        ? (Object.values(MB.linkedEntities.work_type).find(workType => workType.name === 'Song')?.id ?? null)
-        : workState.originalEditData.type_id,
+    type_id: [EssenceType.Song, EssenceType.ChoirSong].includes(essenceType(track))
+      ? (Object.values(MB.linkedEntities.work_type).find(workType => workType.name === 'Song')?.id ?? null)
+      : workState.originalEditData.type_id,
     languages: mergeArrays(
       workState.originalEditData.languages,
       (() => {
         switch (essenceType(track)) {
-          case EssenceType.NoLyrics:
+          case EssenceType.LightMusicNoWords:
+          case EssenceType.Jazz:
             return [LANGUAGE_ZXX_ID];
           case EssenceType.Song:
+          case EssenceType.ChoirSong:
             return (() => {
               switch (workLanguage(track)) {
                 case WorkLanguage.Hebrew:


### PR DESCRIPTION
Remove the `dist` directory from the `src` path to prevent infinite triggers in rollup watch. Introduce additional work essence types to improve functionality.