### PR TITLE
Fix importing a single work from an album

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+cat "$1" | yarn cspell lint --language-id git stdin
 yarn commitlint --edit $1

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -43,9 +43,13 @@ overrides:
     ignoreRegExpList:
       - /@match .*/g
 languageSettings:
-  - enabled: true
-    languageId: typescriptreact
+  - languageId: typescriptreact
     ignoreRegExpList:
       - /^import .*/mg
       - /class=\{[^}]+\}/g
       - /class="[^"]+"/g
+  - languageId: git
+    ignoreRegExpList:
+      - /#\\s.*/ # comments
+      - /`.*?`/ # inline code
+      - /(```+)\\s?[\\s\\S]+?\\1/g # code block

--- a/src/acum-work-import/CHANGELOG.md
+++ b/src/acum-work-import/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-* allow importing a single work from releaes editor ([94be6c9](https://github.com/dvirtz/musicbrainz-scripts/commit/94be6c9b9838beca8d9858f36729f2dff97a9947)), closes [#48](https://github.com/dvirtz/musicbrainz-scripts/issues/48)
+* allow importing a single work from release editor ([94be6c9](https://github.com/dvirtz/musicbrainz-scripts/commit/94be6c9b9838beca8d9858f36729f2dff97a9947)), closes [#48](https://github.com/dvirtz/musicbrainz-scripts/issues/48)
 
 ## [@dvirtz/acum-work-import-v1.7.0](https://github.com/dvirtz/musicbrainz-scripts/compare/@dvirtz/acum-work-import-v1.6.2...@dvirtz/acum-work-import-v1.7.0) (2025-01-07)
 

--- a/src/acum-work-import/import-album.ts
+++ b/src/acum-work-import/import-album.ts
@@ -31,69 +31,132 @@ import {workEditDataEqual} from './ui/work-edit-data';
 import {WorkStateWithEditDataT} from './work-state';
 import {addWork, linkWriters} from './works';
 
+type SelectedMediums = Set<[MediumWithRecordingsT, MediumRecordingStateTreeT]>;
+type SelectedRecordings = ReadonlyArray<readonly [number, WorkBean, MediumRecordingStateT]>;
+// map of promises so that we don't fetch the same artist multiple times
+type ArtistCache = Map<IPBaseNumber, Promise<ArtistT | null>>;
+type SetProgress = Setter<readonly [number, string]>;
+
 export async function importAlbum(
   entityId: string,
   entity: Entity,
   addWarning: AddWarning,
-  setProgress: Setter<readonly [number, string]>
+  setProgress: SetProgress
 ): Promise<boolean> {
   setProgress([0, 'Loading album info']);
 
+  const noSelection = (MB.relationshipEditor.state.selectedRecordings?.size ?? 0) === 0;
+  const mediums = selectedMediums(entity, noSelection, addWarning);
+  const recordings = await selectedRecordings(entity, entityId, noSelection, mediums);
+
+  return await importSelectedWorks(entityId, recordings, addWarning, setProgress);
+}
+
+async function importSelectedWorks(
+  entityId: string,
+  selectedRecordings: SelectedRecordings,
+  addWarning: AddWarning,
+  setProgress: SetProgress
+) {
   const addTrackWarning = (position: number) => (warning: string) => addWarning(`Track ${position}: ${warning}`);
 
-  // map of promises so that we don't fetch the same artist multiple times
-  const artistCache = new Map<IPBaseNumber, Promise<ArtistT | null>>();
+  const artistCache: ArtistCache = new Map();
 
-  const linkArrangers = async (
-    recording: RecordingT,
-    arrangers: ReadonlyArray<Creator> | undefined,
-    creators: Creators | undefined,
-    addWarning: AddWarning
-  ) => {
-    await linkArtists(
-      artistCache,
-      arrangers,
-      creators,
-      (artist: ArtistT) => addArrangerRelationship(recording, artist),
-      addWarning
-    );
-  };
-
-  const noSelection = (MB.relationshipEditor.state.selectedRecordings?.size ?? 0) === 0;
-
-  const selectedMediums = new Set(
-    noSelection
-      ? MB.tree.iterate(MB.relationshipEditor.state.mediums)
-      : MB.tree
-          .iterate(MB.relationshipEditor.state.mediums)
-          .filter(([, recordingStateTree]) =>
-            MB.tree.iterate(recordingStateTree).some(recording => recording.isSelected)
-          )
+  return await lastValueFrom(
+    from(selectedRecordings).pipe(
+      map(([position, workBean, recordingState]) => [workBean, recordingState, addTrackWarning(position)] as const),
+      tap(([workBean, recordingState, addWarning]) => {
+        const recording = recordingState.recording;
+        if (trackName(workBean) != recording.name) {
+          if (compareInsensitive(trackName(workBean), recording.name) === 0) {
+            workBean.workEngName = workBean.workHebName = recording.name;
+          } else {
+            addWarning(`Work name of ${recording.name} is different from recording name, please verify`);
+          }
+        }
+      }),
+      mergeMap(
+        async ([workBean, recordingState, addWarning]) =>
+          [workBean, recordingState.recording, await addWork(workBean, recordingState, addWarning), addWarning] as const
+      ),
+      mergeMap(args => linkCreators(artistCache, ...args)),
+      connect(shared =>
+        merge(
+          shared.pipe(maybeSetEditNote(entityId, addWarning)),
+          shared.pipe(updateProgress(selectedRecordings, setProgress), ignoreElements())
+        )
+      )
+    )
   );
+}
 
-  switch (selectedMediums.size) {
-    case 0:
-      addWarning('select at least one recording');
-      return false;
-    case 1:
-      if (
-        entity == Entity.Work &&
-        MB.relationshipEditor.state.selectedRecordings?.size !== 1 &&
-        selectedMediums.size !== 1
-      ) {
-        addWarning('select exactly one recording');
-        return false;
+function updateProgress(selectedRecordings: SelectedRecordings, setProgress: SetProgress) {
+  return pipe(
+    scan(accumulator => accumulator + 1, 0),
+    map(count => [count / selectedRecordings.length, `Loaded ${count}/${selectedRecordings.length} works`] as const),
+    endWith([1, 'Done'] as const),
+    tap(setProgress)
+  );
+}
+
+function maybeSetEditNote(entityId: string, addWarning: AddWarning) {
+  return pipe(
+    count((workState: WorkStateWithEditDataT) => !workEditDataEqual(workState.editData, workState.originalEditData)),
+    map(editedCount => editedCount > 0),
+    tap(hasEdits => {
+      if (hasEdits) {
+        addEditNote(`Imported from ${albumUrl(entityId)}`);
+      } else {
+        addWarning('All works are up to date');
       }
-      break;
-    default:
-      addWarning('select recordings only from a single medium');
-      return false;
-  }
+    })
+  );
+}
 
+async function linkCreators(
+  artistCache: ArtistCache,
+  workBean: WorkBean,
+  recording: RecordingT,
+  workState: WorkStateWithEditDataT,
+  addWarning: AddWarning
+): Promise<WorkStateWithEditDataT> {
+  const work = workState.work;
+  await linkWriters(
+    artistCache,
+    workBean,
+    (artist: ArtistT, linkTypeId: number) => addWriterRelationship(work, artist, linkTypeId),
+    addWarning
+  );
+  await linkArrangers(artistCache, recording, workBean.arrangers, workBean.creators, addWarning);
+  return workState;
+}
+
+async function linkArrangers(
+  artistCache: ArtistCache,
+  recording: RecordingT,
+  arrangers: ReadonlyArray<Creator> | undefined,
+  creators: Creators | undefined,
+  addWarning: AddWarning
+) {
+  await linkArtists(
+    artistCache,
+    arrangers,
+    creators,
+    (artist: ArtistT) => addArrangerRelationship(recording, artist),
+    addWarning
+  );
+}
+
+async function selectedRecordings(
+  entity: Entity,
+  entityId: string,
+  noSelection: boolean,
+  selectedMediums: SelectedMediums = new Set()
+): Promise<SelectedRecordings> {
   const workBeans: ReadonlyArray<WorkBean> =
     entity == Entity.Work ? ((await fetchWork(entityId)) ?? []) : (await albumInfo(entityId)).tracks;
 
-  const selectedRecordings = await lastValueFrom(
+  return await lastValueFrom(
     of(head(selectedMediums.values())).pipe(
       filter(
         (mediumAndRecordings): mediumAndRecordings is [MediumWithRecordingsT, MediumRecordingStateTreeT] =>
@@ -110,66 +173,37 @@ export async function importAlbum(
         return recordingState != null && (noSelection || recordingState.isSelected);
       }),
       zipWith(from(workBeans)),
-      map(([[position, recordingState], track]) => [position, track, recordingState] as const),
+      map(([[position, recordingState], workBean]) => [position, workBean, recordingState] as const),
       toArray()
     )
   );
+}
 
-  const linkCreators = async (
-    track: WorkBean,
-    recording: RecordingT,
-    workState: WorkStateWithEditDataT,
-    addWarning: AddWarning
-  ): Promise<WorkStateWithEditDataT> => {
-    const work = workState.work;
-    await linkWriters(
-      artistCache,
-      track,
-      (artist: ArtistT, linkTypeId: number) => addWriterRelationship(work, artist, linkTypeId),
-      addWarning
-    );
-    await linkArrangers(recording, track.arrangers, track.creators, addWarning);
-    return workState;
-  };
+function selectedMediums(entity: Entity, noSelection: boolean, addWarning: AddWarning): SelectedMediums | undefined {
+  const selected = new Set(
+    noSelection
+      ? MB.tree.iterate(MB.relationshipEditor.state.mediums)
+      : MB.tree
+          .iterate(MB.relationshipEditor.state.mediums)
+          .filter(([, recordingStateTree]) =>
+            MB.tree.iterate(recordingStateTree).some(recording => recording.isSelected)
+          )
+  );
 
-  const maybeSetEditNote = pipe(
-    count((workState: WorkStateWithEditDataT) => !workEditDataEqual(workState.editData, workState.originalEditData)),
-    map(editedCount => editedCount > 0),
-    tap(hasEdits => {
-      if (hasEdits) {
-        addEditNote(`Imported from ${albumUrl(entityId)}`);
-      } else {
-        addWarning('All works are up to date');
+  switch (selected.size) {
+    case 0:
+      addWarning('select at least one recording');
+      return;
+    case 1:
+      if (entity == Entity.Work && MB.relationshipEditor.state.selectedRecordings?.size !== 1 && selected.size !== 1) {
+        addWarning('select exactly one recording');
+        return;
       }
-    })
-  );
+      break;
+    default:
+      addWarning('select recordings only from a single medium');
+      return;
+  }
 
-  const updateProgress = pipe(
-    scan(accumulator => accumulator + 1, 0),
-    map(count => [count / selectedRecordings.length, `Loaded ${count}/${selectedRecordings.length} works`] as const),
-    endWith([1, 'Done'] as const),
-    tap(setProgress)
-  );
-
-  return await lastValueFrom(
-    from(selectedRecordings).pipe(
-      map(([position, track, recordingState]) => [track, recordingState, addTrackWarning(position)] as const),
-      tap(([track, recordingState, addWarning]) => {
-        const recording = recordingState.recording;
-        if (trackName(track) != recording.name) {
-          if (compareInsensitive(trackName(track), recording.name) === 0) {
-            track.workEngName = track.workHebName = recording.name;
-          } else {
-            addWarning(`Work name of ${recording.name} is different from recording name, please verify`);
-          }
-        }
-      }),
-      mergeMap(
-        async ([track, recordingState, addWarning]) =>
-          [track, recordingState.recording, await addWork(track, recordingState, addWarning), addWarning] as const
-      ),
-      mergeMap(args => linkCreators(...args)),
-      connect(shared => merge(shared.pipe(maybeSetEditNote), shared.pipe(updateProgress, ignoreElements())))
-    )
-  );
+  return selected;
 }


### PR DESCRIPTION
Addressed the issue where importing a single work from an album incorrectly displayed a message stating that all works are up to date. Improved the import logic to ensure the correct work is imported when selected.

Fixes #50