### PR TITLE
Add Sketch essence type and improve song handling utilities

### DIFF
--- a/src/acum-work-import/acum.ts
+++ b/src/acum-work-import/acum.ts
@@ -133,6 +133,7 @@ export enum EssenceType {
   LightMusicNoWords = '15', // Light music (without words)
   Song = '30', // Popular song
   Jazz = '40', // Original jazz work
+  Sketch = '41', // Audio skit
   ChoirSong = '53', // Original song for 4 part choir
   /** @knipignore */
   Unknown = '-1',
@@ -147,6 +148,10 @@ function stringToEnum<T>(value: string, enumType: {[s: string]: T}): T {
 
 export function essenceType(track: WorkBean): EssenceType {
   return stringToEnum(track.versionEssenceType, EssenceType);
+}
+
+export function isSong(track: WorkBean): boolean {
+  return [EssenceType.Song, EssenceType.ChoirSong].includes(essenceType(track));
 }
 
 export enum WorkLanguage {

--- a/src/acum-work-import/ui/release-editor-ui.tsx
+++ b/src/acum-work-import/ui/release-editor-ui.tsx
@@ -57,7 +57,7 @@ function AcumImporter() {
 
   return (
     <>
-      <ImportForm entityTypes={['Album', 'Work', 'Version']} onSubmit={importWorks} idPattern="[12][0-9A-Z]+">
+      <ImportForm entityTypes={['Album', 'Version', 'Work']} onSubmit={importWorks} idPattern="[0-9A-Z]+">
         <Button id="acum-work-submit" class="worksubmit" disabled={submissionDisabled()} onclick={submitWorks}>
           <span>Submit works</span>
         </Button>

--- a/src/acum-work-import/ui/work-edit-data.tsx
+++ b/src/acum-work-import/ui/work-edit-data.tsx
@@ -73,7 +73,7 @@ export async function workEditData(
   return {
     originalEditData,
     editData: {
-      name: originalEditData.name,
+      name: originalEditData.name || trackName(track),
       comment: originalEditData.comment,
       type_id: isSong(track)
         ? (Object.values(await workTypes).find(workType => workType.name === 'Song')?.id ?? null)

--- a/src/acum-work-import/ui/work-edit-data.tsx
+++ b/src/acum-work-import/ui/work-edit-data.tsx
@@ -7,7 +7,7 @@ import {mergeArrays} from 'src/common/lib/merge-arrays';
 import {LANGUAGE_ZXX_ID} from 'src/common/musicbrainz/constants';
 import {fetchEditParams, urlFromMbid} from 'src/common/musicbrainz/edits';
 import {workAttributeTypes, workLanguages, workTypes} from 'src/common/musicbrainz/type-info';
-import {essenceType, EssenceType, WorkBean, workISWCs, workLanguage, WorkLanguage} from '../acum';
+import {essenceType, EssenceType, isSong, trackName, WorkBean, workISWCs, workLanguage, WorkLanguage} from '../acum';
 import {WorkStateWithEditDataT} from '../work-state';
 import {AddWarning} from './warnings';
 
@@ -75,7 +75,7 @@ export async function workEditData(
     editData: {
       name: originalEditData.name,
       comment: originalEditData.comment,
-      type_id: [EssenceType.Song, EssenceType.ChoirSong].includes(essenceType(track))
+      type_id: isSong(track)
         ? (Object.values(await workTypes).find(workType => workType.name === 'Song')?.id ?? null)
         : originalEditData.type_id,
       languages: mergeArrays(
@@ -87,6 +87,7 @@ export async function workEditData(
               return [LANGUAGE_ZXX_ID];
             case EssenceType.Song:
             case EssenceType.ChoirSong:
+            case EssenceType.Sketch:
               return await (async () => {
                 switch (workLanguage(track)) {
                   case WorkLanguage.Hebrew:

--- a/src/acum-work-import/ui/work-editor-ui.tsx
+++ b/src/acum-work-import/ui/work-editor-ui.tsx
@@ -11,7 +11,7 @@ function AcumImporter(props: {form: HTMLFormElement}) {
   async function importWork(entity: Entity<'Work'>) {
     clearWarnings();
     try {
-      return await tryImportWork(entity, props.form, addWarning);
+      await tryImportWork(entity, props.form, addWarning);
     } catch (err) {
       console.error(err);
       addWarning(`Import failed: ${String(err)}`);

--- a/src/acum-work-import/works.ts
+++ b/src/acum-work-import/works.ts
@@ -8,9 +8,10 @@ import {
   REL_STATUS_ADD,
   REL_STATUS_REMOVE,
   TRANSLATOR_LINK_TYPE_ID,
+  WRITER_LINK_TYPE_ID,
 } from 'src/common/musicbrainz/constants';
 import {iterateRelationshipsInTargetTypeGroup} from 'src/common/musicbrainz/type-group';
-import {trackName, WorkBean} from './acum';
+import {isSong, trackName, WorkBean} from './acum';
 import {linkArtists} from './artists';
 import {createRelationshipState} from './relationships';
 import {AddWarning} from './ui/warnings';
@@ -139,7 +140,7 @@ export async function linkWriters(
     artistCache,
     [...(track.authors ?? []), ...(track.composersAndAuthors ?? [])],
     track.creators,
-    artist => doLink(artist, LYRICIST_LINK_TYPE_ID),
+    artist => doLink(artist, isSong(track) ? LYRICIST_LINK_TYPE_ID : WRITER_LINK_TYPE_ID),
     addWarning
   );
   await linkArtists(

--- a/src/common/musicbrainz/constants.ts
+++ b/src/common/musicbrainz/constants.ts
@@ -14,6 +14,7 @@ export const COMPOSER_LINK_TYPE_ID = 168;
 export const LYRICIST_LINK_TYPE_ID = 165;
 export const ARRANGER_LINK_TYPE_ID = 297;
 export const TRANSLATOR_LINK_TYPE_ID = 872;
+export const WRITER_LINK_TYPE_ID = 167;
 export const REL_STATUS_NOOP: RelationshipEditStatusT = 0;
 export const REL_STATUS_ADD: RelationshipEditStatusT = 1;
 export const REL_STATUS_EDIT: RelationshipEditStatusT = 2;


### PR DESCRIPTION
Introduce a new essence type for Sketch and a utility function to determine if a track is a song. Correct the ID pattern for imports and ensure proper handling of original track names. Refactor redundant return statements and adjust writer linking based on track type.