### PR TITLE
Fix wait for relationship editor state

### DIFF
--- a/scripts/acum-work-import/src/app.ts
+++ b/scripts/acum-work-import/src/app.ts
@@ -4,20 +4,40 @@ import {createWorkEditorUI} from './ui/work-editor-ui';
 
 main().catch(console.error);
 
+function waitForEditorState() {
+  return new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (MB.relationshipEditor.state) {
+        console.debug('Editor state is ready');
+        clearInterval(interval);
+        resolve(MB.relationshipEditor.state);
+      }
+    }, 50); // Check every 50ms
+  });
+}
+
 async function main() {
+  console.debug('start');
   await registerSettingsDialog();
-  new MutationObserver((_mutations, observer) => {
+  await waitForEditorState();
+  const createUI = (_mutations: MutationRecord[], observer: MutationObserver) => {
     if (location.pathname.startsWith('/release/')) {
       if (document.querySelector('button.submit')) {
+        console.debug('Creating release editor');
         createReleaseEditorUI();
         observer.disconnect();
       }
     } else {
       const workForm = document.querySelector<HTMLFormElement>('form.edit-work');
       if (workForm) {
+        console.debug('Creating work editor');
         createWorkEditorUI(workForm);
         observer.disconnect();
       }
     }
-  }).observe(document.body, {childList: true, subtree: true});
+  };
+  const observer = new MutationObserver(createUI);
+  observer.observe(document.body, {childList: true, subtree: true});
+  // Initial call to createEditor to handle the case where the editor is already present
+  createUI([], observer);
 }


### PR DESCRIPTION
Implement a function to wait for the relationship editor state to be ready before proceeding with UI creation, ensuring proper initialization.