### PR TITLE
Match artists by ACUM link

### DIFF
--- a/lib/musicbrainz-types/index.d.ts
+++ b/lib/musicbrainz-types/index.d.ts
@@ -1070,4 +1070,12 @@ declare global {
       };
 
   type LoadedTracksMapT = ReadonlyMap<number, ReadonlyArray<TrackWithRecordingT>>;
-}
+
+  type UrlRelsSearchResultsT<K extends NonUrlRelatableEntityTypeT> = {
+    relations: ReadonlyArray<{
+      [key in K]: {
+        id: MBID;
+      };
+    }>;
+  };
+} // end of global declaration

--- a/scripts/acum-work-import/playwright.config.ts
+++ b/scripts/acum-work-import/playwright.config.ts
@@ -1,8 +1,8 @@
 import {defineConfig} from 'test-support';
 
 export default defineConfig('https://test.musicbrainz.org', {
-  timeout: 120_000,
+  timeout: 180_000,
   expect: {
-    timeout: 30_000,
+    timeout: 60_000,
   },
 });

--- a/scripts/acum-work-import/src/acum.ts
+++ b/scripts/acum-work-import/src/acum.ts
@@ -1,6 +1,6 @@
-import {filter, lastValueFrom, map, mergeAll, mergeMap, range, startWith, toArray} from 'rxjs';
 import {tryFetchJSON} from 'fetch';
 import {formatISWC} from 'musicbrainz-ext';
+import {filter, lastValueFrom, map, mergeAll, mergeMap, range, startWith, toArray} from 'rxjs';
 
 export type IPBaseNumber = string;
 
@@ -97,10 +97,11 @@ type WorkInfoResponse = Response<
   }
 >;
 
+const baseUrl = 'https://nocs.acum.org.il/acumsitesearchdb';
+// cSpell:ignoreRegExp `\${baseUrl}\/[^`]*`
+
 async function fetchWork(workId: string): Promise<ReadonlyArray<WorkBean>> {
-  const result = await tryFetchJSON<WorkInfoResponse>(
-    `https://nocs.acum.org.il/acumsitesearchdb/getworkinfo?workId=${workId}`
-  );
+  const result = await tryFetchJSON<WorkInfoResponse>(`${baseUrl}/getworkinfo?workId=${workId}`);
   if (result) {
     if (result.errorCode == 0) {
       if (result.data.workVersions) {
@@ -112,7 +113,7 @@ async function fetchWork(workId: string): Promise<ReadonlyArray<WorkBean>> {
               mergeMap(
                 async pageNumber =>
                   await tryFetchJSON<WorkInfoPageResponse>(
-                    `https://nocs.acum.org.il/acumsitesearchdb/getworkinfo?workId=${workId}&pageNumber=${pageNumber}`
+                    `${baseUrl}/getworkinfo?workId=${workId}&pageNumber=${pageNumber}`
                   )
               ),
               filter(
@@ -142,9 +143,7 @@ function versionWorkId(versionId: string) {
 }
 
 async function fetchAlbum(albumId: string): Promise<AlbumBean> {
-  const result = await tryFetchJSON<AlbumInfoResponse>(
-    `https://nocs.acum.org.il/acumsitesearchdb/getalbuminfo?albumId=${albumId}`
-  );
+  const result = await tryFetchJSON<AlbumInfoResponse>(`${baseUrl}/getalbuminfo?albumId=${albumId}`);
   if (result) {
     if (result.errorCode == 0) {
       return result.data.albumBean;
@@ -264,10 +263,14 @@ async function fetchWorksUncached(entity: Entity): Promise<ReadonlyArray<WorkBea
 export function entityUrl(entity: Entity) {
   switch (entity.entityType) {
     case 'Work':
-      return `https://nocs.acum.org.il/acumsitesearchdb/work?workid=${entity.id}`;
+      return `${baseUrl}/work?workid=${entity.id}`;
     case 'Album':
-      return `https://nocs.acum.org.il/acumsitesearchdb/album?albumid=${entity.id}`;
+      return `${baseUrl}/album?albumid=${entity.id}`;
     case 'Version':
-      return `https://nocs.acum.org.il/acumsitesearchdb/version?workid=${versionWorkId(entity.id)}&versionid=${entity.id}`;
+      return `${baseUrl}/version?workid=${versionWorkId(entity.id)}&versionid=${entity.id}`;
   }
+}
+
+export function creatorUrl(creator: CreatorBase<string>) {
+  return `${baseUrl}/results?creatorid=${creator.creatorIpBaseNumber}`;
 }

--- a/scripts/acum-work-import/src/artists.ts
+++ b/scripts/acum-work-import/src/artists.ts
@@ -1,7 +1,7 @@
 import {compareInsensitive, tryFetchJSON} from 'musicbrainz-ext';
 import {filter, from, mergeMap, tap} from 'rxjs';
 import {executePipeline} from 'rxjs-ext';
-import {Creator, CreatorFull, Creators, IPBaseNumber, RoleCode} from './acum';
+import {Creator, CreatorFull, Creators, creatorUrl, IPBaseNumber, RoleCode} from './acum';
 import {AddWarning} from './ui/warnings';
 
 function nameMatch(creator: CreatorFull, artistName: string): boolean {
@@ -39,6 +39,13 @@ async function findArtist(
     const byIpi = await tryFetchJSON<ArtistSearchResultsT>(`/ws/2/artist?query=ipi:${creator.number}&limit=1&fmt=json`);
     if (byIpi && byIpi.artists.length > 0) {
       return byIpi.artists[0].id;
+    }
+
+    const byLink = await tryFetchJSON<UrlRelsSearchResultsT<'artist'>>(
+      `/ws/2/url?resource=${creatorUrl(creator)}&inc=artist-rels&fmt=json`
+    );
+    if (byLink && byLink.relations[0].artist.id) {
+      return byLink.relations[0].artist.id;
     }
 
     const byName = await tryFetchJSON<ArtistSearchResultsT>(

--- a/scripts/acum-work-import/tests/fixtures/musicbrainz-page.ts
+++ b/scripts/acum-work-import/tests/fixtures/musicbrainz-page.ts
@@ -1,5 +1,6 @@
 import {Page} from '@playwright/test';
 import * as path from 'path';
+
 export class MusicbrainzPage {
   protected constructor(public readonly page: Page) {}
 

--- a/scripts/acum-work-import/tests/work-editor.spec.ts
+++ b/scripts/acum-work-import/tests/work-editor.spec.ts
@@ -51,4 +51,44 @@ test.describe('work editor', () => {
       `\n----\nImported from ${workUrl} using userscript version 1.0.0 from https://homepage.com.`
     );
   });
+
+  test('can find all artists', async ({page, musicbrainzPage}) => {
+    await musicbrainzPage.goto('/work/create');
+
+    const versionId = '1119554001';
+    const workId = versionId.substring(0, versionId.length - 3);
+    const workUrl = `https://nocs.acum.org.il/acumsitesearchdb/work?workid=${workId}`;
+
+    const input = page.getByPlaceholder('Version/Work ID');
+    await input.fill(workUrl);
+    await expect(input).toHaveValue(workId);
+
+    const importButton = page.getByRole('button', {name: 'Import work from ACUM'});
+    await importButton.click();
+
+    const name = page.getByRole('textbox', {name: 'Name'});
+    await expect(name).toHaveValue('OPEN UP YOUR EYES');
+
+    const typeText = await selectBoxText(page.getByRole('combobox', {name: 'Type'}));
+    expect(typeText).toBe('Song');
+
+    const attributeType = await selectBoxText(page.locator('select[name="edit-work.attributes.0.type_id"]'));
+    expect(attributeType).toMatch(/\s*ACUM ID/);
+
+    const attributeValue = page.locator('input[name="edit-work.attributes.0.value"]');
+    await expect(attributeValue).toHaveValue(versionId);
+
+    for (const role of ['composer', 'lyricist']) {
+      const roleRow = page.getByRole('row', {name: role});
+      const links = roleRow.getByRole('link');
+      await expect(links).toHaveCount(2);
+      // cspell: disable-next-line
+      await expect(links).toHaveText(['Robb Huxley', 'סטן סולומון']);
+    }
+
+    const editNote = page.getByRole('textbox', {name: 'Edit note'});
+    await expect(editNote).toHaveValue(
+      `\n----\nImported from ${workUrl} using userscript version 1.0.0 from https://homepage.com.`
+    );
+  });
 });

--- a/scripts/setlistfm-musicbrainz-import/package.json
+++ b/scripts/setlistfm-musicbrainz-import/package.json
@@ -8,6 +8,7 @@
     "common-ui": "workspace:*",
     "fetch": "workspace:*",
     "musicbrainz-ext": "workspace:*",
+    "musicbrainz-types": "workspace:*",
     "rxjs": "^7.8.1",
     "rxjs-ext": "workspace:*",
     "solid-js": "^1.9.4"

--- a/scripts/setlistfm-musicbrainz-import/src/event.ts
+++ b/scripts/setlistfm-musicbrainz-import/src/event.ts
@@ -286,17 +286,10 @@ function parseTime(query: string) {
 }
 
 async function findEvent(url: string) {
-  type Event = {
-    relations: ReadonlyArray<{
-      event: {
-        id: string;
-      };
-    }>;
-  };
-  const existingEvent = await tryFetchJSON<Event>(
+  const existingEvent = await tryFetchJSON<UrlRelsSearchResultsT<'event'>>(
     `https://musicbrainz.org/ws/2/url?resource=${url}&inc=event-rels&fmt=json`
   );
-  return existingEvent && existingEvent['relations'][0]['event'].id;
+  return existingEvent && existingEvent.relations[0].event.id;
 }
 
 function addWarningIcon(type: string, query: string, afterElement: Element) {

--- a/scripts/setlistfm-musicbrainz-import/src/place.ts
+++ b/scripts/setlistfm-musicbrainz-import/src/place.ts
@@ -21,17 +21,10 @@ export async function handleVenuePage() {
 }
 
 export async function findVenue(url: string) {
-  type Venue = {
-    relations: ReadonlyArray<{
-      place: {
-        id: string;
-      };
-    }>;
-  };
-  const existingVenue = await tryFetchJSON<Venue>(
+  const existingVenue = await tryFetchJSON<UrlRelsSearchResultsT<'place'>>(
     `https://musicbrainz.org/ws/2/url?resource=${url}&inc=place-rels&fmt=json`
   );
-  return existingVenue && existingVenue['relations'][0]['place'].id;
+  return existingVenue && existingVenue.relations[0].place.id;
 }
 
 function submitPlace() {

--- a/scripts/setlistfm-musicbrainz-import/tests/fixtures/setlistfm-page.ts
+++ b/scripts/setlistfm-musicbrainz-import/tests/fixtures/setlistfm-page.ts
@@ -1,4 +1,5 @@
 import {Page} from '@playwright/test';
+import * as path from 'path';
 
 export class SetlistFmPage {
   constructor(public readonly page: Page) {}
@@ -21,7 +22,7 @@ export class SetlistFmPage {
 
   private async injectUserScript() {
     await this.page.addScriptTag({
-      path: 'dist/setlistfm-musicbrainz-import.user.js',
+      path: path.resolve(import.meta.dirname, '..', '..', 'dist', 'setlistfm-musicbrainz-import.user.js'),
     });
   }
 }

--- a/scripts/setlistfm-musicbrainz-import/tsconfig.json
+++ b/scripts/setlistfm-musicbrainz-import/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "../../tsconfig.userscript.json"
+  "extends": "../../tsconfig.userscript.json",
+  "compilerOptions": {
+    "types": [
+      "musicbrainz-types",
+      "@types/greasemonkey",
+      "node",
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,6 +3356,7 @@ __metadata:
     eslint: "npm:*"
     fetch: "workspace:*"
     musicbrainz-ext: "workspace:*"
+    musicbrainz-types: "workspace:*"
     rollup: "npm:*"
     rxjs: "npm:^7.8.1"
     rxjs-ext: "workspace:*"


### PR DESCRIPTION
Implement functionality to match artists using ACUM links, enhancing the ability to find artists without IPI. This change integrates new URL relations for artist matching and updates relevant functions and tests accordingly.

Fixes #79