### PR TITLE
fix: support all ACUM work types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "yarn turbo watch check-types lint",
+    "dev": "yarn turbo watch check-types lint --experimental-write-cache",
     "release": "turbo run release",
     "test": "turbo run test",
     "ci": "yarn check-types && yarn lint && yarn build",

--- a/scripts/acum-work-import/src/acum-work-type.ts
+++ b/scripts/acum-work-import/src/acum-work-type.ts
@@ -1,0 +1,54 @@
+// cspell:ignoreRegExp /\/\/ .*/
+export enum AcumWorkType {
+  StoryForEducationalProgram = '910', // סיפורת לבתי ספר
+  TvScriptForEducationalProgram = '911', // תסריט לבתי ספר
+  Jingle = '912', // זמריר
+  Promo = '914', // פרומו
+  DocumentaryDidacticalTvOrRadioScript = '920', // תסכית/תסריט דידקטי או דוקומנטרי
+  StoryForChildYouth = '930', // סיפורת לילד/נוער
+  TvScriptForChildYouth = '931', // תסריט לילד/נוער
+  ChildrenDubbingScript = '932', // תסריט ילדים מדובב
+  Recitation = '933', // קטעי מלל או דקלום בקלטת ילדים
+  AudioVisualSkit = '940', // מערכון אודיו ויזואלי
+  AudioSkit = '941', // מערכון אודיו
+  LiteratureNonFiction = '945', // תמליל ומסה ספרותית
+  Prose = '950', // סיפורת
+  Storyteller = '951', // סיפור במסגרת מספרי סיפורים
+  Poetry = '955', // שירה
+  DramaticWorksInProse = '960', // מחזה פרוזה
+  OriginalScriptForTvSeries = '965', // תסריט מקורי לסדרת טלויזיה
+  OriginalDramaticTvOrRadioScript = '966', // תסכית/תסריט דרמטי מקורי
+  DramaWithOriginalMusic = '970', // מחזה עם מוס. מקורית שתזמונה לפחות 1/3 מהתזמון הכולל
+  DramaticLyricalWorks = '971', // מחזה פיוט
+  Poetry2 = '972', // פיוט
+  SyncLicensingOnly = '990', // לצורך רשיון פרטני לפרסומת והסרטה
+  KaraokeMobilePhone = '0KA', // קריוקי בסלולאר
+  PopularSong = '030', // שיר זמר,פופ,רוק
+  WorkForChapel3Voices = '036', // יצירה למקהלת א-קאפלה עד 3 קולות
+  OriginalJazzWork = '040', // קטע מולחן בסגנון ג׳ז
+  StationIdentificationMusic = '009', // אות תחנה/מעברון תחנה
+  Mailbox = '0MB', // מענה קולי בסלולאר
+  SyncLicensingOnly2 = '090', // לצורך רשיון פרטני לפרסומת והסרטה
+  SongAndMessage = '9SA', // שיר וברכה בסלולאר
+  ChamberMusic12Instruments = '050', // (מוסיקה קאמרית ל 2-1  כלים/תפקידים (עם או בלי זמרה
+  ChamberMusic311Instruments = '051', // (מוסיקה קאמרית ל 11-3 כלים/תפקידים (עם או בלי זמרה
+  OriginalSongFor4PartChoir = '053', // יצירה למקהלת א-קאפלה ל-4 קולות ויותר
+  ProgramIdentificationMusic = '010', // אות תוכנית
+  ElectroAcousticWorks = '055', // מוסיקה אלקטרו-אקוסטית
+  InterludeInProgram = '011', // מעברון בתוכנית
+  MusicalPlay = '056', // מחזמר מקורי בשלמותו / בחלקים מהותיים
+  Jingle2 = '012', // זמריר
+  SymphonyChamberMusFor12InstAndMore = '057', // (מוסיקה לתז׳ סימפ/קאמרית מ-12 כלים (עם או בלי מלים
+  MusicForFilms = '013', // מוסיקה לסרטים
+  DramaticMusicalWorksWithOrch = '058', // יצירה דרמטית-מוסיקלית עם תזמורת-אופרה
+  PromoForStation = '014', // פרומו תחנה
+  LightMusicWithoutWords = '015', // (מוסיקה קלה וקלאסית קלה לתזמורת (ללא מילים
+  Promo2 = '016', // פרומו תוכנית
+  LibraryWork = '020', // (מוסיקת ספריה (עם או בלי מילים
+  Ringtone = '0RT', // (רינגטון (צלצול טלפון
+  InstrumentalMusicForDanceElectronMusic = '025', // מוסיקה כלית לריקודים,מוסיקה קלה אלקטרונית
+  TranslationOfForeignWork = '9TW', // תרגום מלים לשיר לועזי
+  SongAndMessage2 = '0SA', // (שיר וברכה (הקראת מלים של פזמון בסלולאר
+  /** @knipignore */
+  Unknown = '-1',
+}

--- a/scripts/acum-work-import/src/acum.ts
+++ b/scripts/acum-work-import/src/acum.ts
@@ -1,6 +1,7 @@
 import {tryFetchJSON} from '@repo/fetch/fetch';
 import {formatISWC} from '@repo/musicbrainz-ext/format-iswc';
 import {filter, lastValueFrom, map, mergeAll, mergeMap, range, startWith, toArray} from 'rxjs';
+import {AcumWorkType} from '#acum-work-type.ts';
 
 export type IPBaseNumber = string;
 
@@ -75,6 +76,14 @@ export type WorkBean = Bean<'org.acum.site.searchdb.dto.bean.WorkBean'> & {
   versionEssenceType: string;
   isMedley: '0' | '1';
   list?: ReadonlyArray<MedleyVersionBean>;
+  origin?: TranslatedOriginalVersion;
+  workType?: string;
+};
+
+type TranslatedOriginalVersion = Bean<'org.acum.site.searchdb.dto.bean.TranslatedOriginalVersionBean'> & {
+  workType: string;
+  versionId: string;
+  workId: string;
 };
 
 type MedleyVersionBean = Bean<'org.acum.site.searchdb.dto.bean.MedleyVersionBean'> & {
@@ -166,17 +175,6 @@ export function trackName(track: WorkBean): string {
   return workLanguage(track) == WorkLanguage.Hebrew ? track.workHebName : track.workEngName;
 }
 
-export enum EssenceType {
-  LightMusicNoWords = '15', // Light music (without words)
-  Song = '30', // Popular song
-  Jazz = '40', // Original jazz work
-  Sketch = '41', // Audio skit
-  ChoirSong = '53', // Original song for 4 part choir
-  Poetry = '55', // Poetry
-  /** @knipignore */
-  Unknown = '-1',
-}
-
 function stringToEnum<T>(value: string, enumType: {[s: string]: T}): T {
   if (Object.values(enumType).includes(value as T)) {
     return value as T;
@@ -184,12 +182,9 @@ function stringToEnum<T>(value: string, enumType: {[s: string]: T}): T {
   return enumType.Unknown!;
 }
 
-export function essenceType(track: WorkBean): EssenceType {
-  return stringToEnum(track.versionEssenceType, EssenceType);
-}
-
-export function isSong(track: WorkBean): boolean {
-  return [EssenceType.Song, EssenceType.ChoirSong].includes(essenceType(track));
+export function workType(track: WorkBean): AcumWorkType {
+  const workType = track.origin ? track.origin.workType : track.workType;
+  return stringToEnum(`${workType}${track.versionEssenceType}`, AcumWorkType);
 }
 
 export enum WorkLanguage {

--- a/scripts/acum-work-import/src/works.ts
+++ b/scripts/acum-work-import/src/works.ts
@@ -1,4 +1,5 @@
-import {isSong, trackName, WorkBean, workISWCs} from '#acum.ts';
+import {AcumWorkType} from '#acum-work-type.ts';
+import {trackName, WorkBean, workISWCs, workType} from '#acum.ts';
 import {linkArtists} from '#artists.ts';
 import {createRelationshipState} from '#relationships.ts';
 import {shouldSearchWorks} from '#ui/settings.tsx';
@@ -247,11 +248,20 @@ export async function linkWriters(
   doLink: (artist: ArtistT, linkTypeID: number) => void,
   addWarning: (message: string) => Set<string>
 ) {
+  const authorLinkTypeId = (() => {
+    switch (workType(track)) {
+      case AcumWorkType.PopularSong:
+      case AcumWorkType.OriginalSongFor4PartChoir:
+        return LYRICIST_LINK_TYPE_ID;
+      default:
+        return WRITER_LINK_TYPE_ID;
+    }
+  })();
   await linkArtists(
     artistCache,
     [...(track.authors ?? []), ...(track.composersAndAuthors ?? [])],
     track.creators,
-    artist => doLink(artist, isSong(track) ? LYRICIST_LINK_TYPE_ID : WRITER_LINK_TYPE_ID),
+    artist => doLink(artist, authorLinkTypeId),
     addWarning
   );
   await linkArtists(

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,12 @@
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
+      "inputs": [
+        "src/**",
+        "package.json",
+        "tsconfig.json",
+        "vite.config.ts"
+      ],
       "outputs": [
         "dist/**"
       ]
@@ -9,21 +15,24 @@
     "check-types": {
       "dependsOn": [
         "^check-types"
-      ]
+      ],
+      "outputLogs": "errors-only"
     },
     "lint": {
       "dependsOn": [
         "^lint"
-      ]
+      ],
+      "outputLogs": "errors-only"
     },
     "//#lint:root": {},
-    "dev": {
-      "persistent": true,
-      "cache": false
-    },
     "test": {
       "dependsOn": [
+        "build",
         "^test"
+      ],
+      "outputs": [
+        "test-results/**",
+        "playwright-report/**"
       ],
       "env": [
         "MB_USERNAME",


### PR DESCRIPTION
Scrapped complete type list from ACUM.
Types are a combination of track.workType with track.versionEssenceType.

fixes #86