### PR TITLE
feat: use workId as ACUM ID instead of versionId

### DIFF
--- a/scripts/acum-work-import/src/work-edit-data.ts
+++ b/scripts/acum-work-import/src/work-edit-data.ts
@@ -181,17 +181,18 @@ export async function workEditData(
           )
         : originalEditData.languages,
       iswcs: mergeArrays(originalEditData.iswcs, (await workISWCs(track.workId)) ?? []),
-      attributes: originalEditData.attributes.find(
-        element => element.type_id === acumTypeId && element.value === track.fullWorkId
-      )
-        ? originalEditData.attributes
-        : [
-            ...originalEditData.attributes,
-            {
-              type_id: acumTypeId,
-              value: track.fullWorkId,
-            },
-          ],
+      // remove older longer ACUM ID attributes
+      attributes: [
+        ...originalEditData.attributes.filter(
+          element =>
+            element.type_id !== acumTypeId ||
+            (element.value !== track.workId && element.value.length == track.workId.length)
+        ),
+        {
+          type_id: acumTypeId,
+          value: track.workId,
+        },
+      ],
     },
   };
 }

--- a/scripts/acum-work-import/src/works.ts
+++ b/scripts/acum-work-import/src/works.ts
@@ -37,7 +37,9 @@ export async function findWork(track: WorkBean) {
           mergeMap(async work => await fetchJSON<WorkLookupResultT>(`/ws/2/work/${work.id}`)),
           filter(
             work =>
-              work.attributes.find(attr => attr.type === 'ACUM ID' && attr.value === track.fullWorkId) !== undefined
+              work.attributes.find(
+                attr => attr.type === 'ACUM ID' && (attr.value === track.workId || attr.value === track.fullWorkId)
+              ) !== undefined
           ),
           defaultIfEmpty(undefined)
         )
@@ -48,7 +50,7 @@ export async function findWork(track: WorkBean) {
 
   if (workId) {
     const work = await fetchJSON<WorkT>(`/ws/js/entity/${workId}`);
-    workCache.set(track.fullWorkId, work);
+    workCache.set(track.workId, work);
     return work;
   }
 
@@ -65,8 +67,8 @@ export async function createNewWork(
   }
 
   const newWork = await (async () => {
-    if (workCache.has(track.fullWorkId)) {
-      return workCache.get(track.fullWorkId)!;
+    if (workCache.has(track.workId)) {
+      return workCache.get(track.workId)!;
     }
     if (await shouldSearchWorks()) {
       const existingWork = await findWork(track);
@@ -78,7 +80,7 @@ export async function createNewWork(
       _fromBatchCreateWorksDialog: true,
       name: trackName(track),
     });
-    workCache.set(track.fullWorkId, newWork);
+    workCache.set(track.workId, newWork);
     return newWork;
   })();
   MB.linkedEntities.work[newWork.id] = newWork;

--- a/scripts/acum-work-import/tests/fixtures/test-release.ts
+++ b/scripts/acum-work-import/tests/fixtures/test-release.ts
@@ -8,7 +8,7 @@ export class TestRelease {
   public static readonly tracks = [
     {
       'id': null,
-      'name': "סע לאט ב'",
+      'name': 'סע לאט ב׳',
       'artist_credit': {
         'names': [
           {

--- a/scripts/acum-work-import/tests/work-editor.spec.ts
+++ b/scripts/acum-work-import/tests/work-editor.spec.ts
@@ -36,7 +36,7 @@ test.describe('work editor', () => {
     expect(attributeType).toMatch(/\s*ACUM ID/);
 
     const attributeValue = page.locator('input[name="edit-work.attributes.0.value"]');
-    await expect(attributeValue).toHaveValue(versionId);
+    await expect(attributeValue).toHaveValue(workId);
 
     for (const role of ['composer', 'lyricist']) {
       const roleRow = page.getByRole('row', {name: role});
@@ -75,7 +75,7 @@ test.describe('work editor', () => {
     expect(attributeType).toMatch(/\s*ACUM ID/);
 
     const attributeValue = page.locator('input[name="edit-work.attributes.0.value"]');
-    await expect(attributeValue).toHaveValue(versionId);
+    await expect(attributeValue).toHaveValue(workId);
 
     for (const role of ['composer', 'lyricist']) {
       const roleRow = page.getByRole('row', {name: role});


### PR DESCRIPTION
It should save works having many ACUM IDs for every version.
See https://community.metabrainz.org/t/work-acum-id/774874
The script will remove older longer ACUM IDs.