### PR TITLE
Disable test parallelism to prevent rate limiting and race conditions

### DIFF
--- a/lib/test-support/src/test-config.ts
+++ b/lib/test-support/src/test-config.ts
@@ -1,7 +1,7 @@
+import {UserscriptTestOptions} from '#userscript-test.ts';
 import {defineConfig as defineTestConfig, devices, type PlaywrightTestConfig} from '@playwright/test';
 import dotenv from 'dotenv';
 import path from 'path';
-import {UserscriptTestOptions} from '#userscript-test.ts';
 
 /**
  * Read environment variables from file.
@@ -14,14 +14,12 @@ dotenv.config({path: path.resolve(import.meta.dirname, '..', '..', '..', '.env')
  */
 export function defineConfig(baseURL: string, userscriptPath: string, options?: PlaywrightTestConfig) {
   return defineTestConfig<UserscriptTestOptions>({
-    /* Run tests in files in parallel */
-    fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
+    /* Can't run in parallel due to Musicbrainz rate limit */
+    workers: 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/scripts/event-seeder/tests/fixtures/test-event.ts
+++ b/scripts/event-seeder/tests/fixtures/test-event.ts
@@ -1,4 +1,4 @@
-import {expect} from '@playwright/test';
+import {expect, type Page} from '@playwright/test';
 import {MBID_REGEXP} from '@repo/musicbrainz-ext/constants';
 import {EventForm} from '@repo/musicbrainz-ext/event-form';
 import {MusicbrainzPage} from '@repo/test-support/musicbrainz-page';
@@ -129,6 +129,23 @@ export class TestEvent {
     return new TestEvent(eventGid);
   }
 
+  private static async expectSeededRelationships(page: Page): Promise<void> {
+    const relEditorRows = page.locator('table.rel-editor-table').locator('tr');
+    for (const [index, relationship] of this.entityRelationships.entries()) {
+      const row = relEditorRows.nth(index);
+      await expect(row.locator('th.link-phrase')).toHaveText(`${relationship.phrase}:`);
+      await expect(row.locator('td.relationship-list')).toContainText(relationship.targetText);
+    }
+
+    const externalLinksRows = page.locator('#external-links-editor').locator('tr');
+    for (const [index, relationship] of this.urlRelationships.entries()) {
+      const linkRow = externalLinksRows.nth(index * 2);
+      await expect(linkRow.locator('input')).toHaveValue(relationship.url);
+      const typeRow = externalLinksRows.nth(index * 2 + 1);
+      await expect(typeRow.locator('label.relationship-name')).toContainText(relationship.linkTypeName);
+    }
+  }
+
   private static async createEvent(musicbrainzPage: MusicbrainzPage): Promise<string> {
     const existingEvent = await musicbrainzPage.page.request.get('/ws/2/event', {
       params: {
@@ -164,6 +181,8 @@ export class TestEvent {
 
     await musicbrainzPage.userscriptPage.goto(`/event/create?${searchParams.toString()}`);
     const page = musicbrainzPage.page;
+
+    await this.expectSeededRelationships(page);
 
     await page.getByRole('textbox', {name: 'Edit note:'}).fill('test');
     await page.getByRole('button', {name: 'Enter edit'}).click();


### PR DESCRIPTION
Disable parallel execution of tests to avoid hitting Musicbrainz rate limits and to prevent race conditions when creating test entities. Additionally, verify relationships before submitting events to ensure data integrity.