### PR TITLE
Use version number as ACUM ID for translated works

### DIFF
--- a/scripts/acum-work-import/src/acum.ts
+++ b/scripts/acum-work-import/src/acum.ts
@@ -57,6 +57,8 @@ type WorkVersion = WorkBean & {
   albumTrackNumber: string;
 };
 
+type Flag = '0' | '1';
+
 export type WorkBean = Bean<'org.acum.site.searchdb.dto.bean.WorkBean'> & {
   work_id: string;
   fullWorkId: string;
@@ -75,7 +77,8 @@ export type WorkBean = Bean<'org.acum.site.searchdb.dto.bean.WorkBean'> & {
   versionIswcNumber?: string;
   versionEssenceType?: string;
   versionId: string;
-  isMedley: '0' | '1';
+  isMedley: Flag;
+  isTranslated: Flag;
   list?: ReadonlyArray<MedleyVersionBean>;
   original?: TranslatedOriginalVersion;
   workType?: string;
@@ -168,8 +171,8 @@ async function fetchAlbum(albumId: string): Promise<AlbumBean> {
   throw new Error(`failed to fetch album ${albumId}`);
 }
 
-export async function workISWCs(workID: string) {
-  return (await fetchWork(workID))
+export async function workISWCs(work: WorkBean) {
+  return (work.isTranslated === '1' ? [] : await fetchWork(workId(work)))
     ?.map(albumVersion => albumVersion.versionIswcNumber)
     .filter((iswc): iswc is string => iswc !== undefined && iswc.length > 0)
     .map(formatISWC);
@@ -302,5 +305,5 @@ export function creatorUrl(creator: CreatorBase<string>) {
 }
 
 export function workId(work: WorkBean) {
-  return work.workId || work.fullWorkId;
+  return work.isTranslated === '1' ? work.versionId : work.workId || work.fullWorkId;
 }

--- a/scripts/acum-work-import/src/import-work.ts
+++ b/scripts/acum-work-import/src/import-work.ts
@@ -75,7 +75,8 @@ export async function importWork(
   }
 
   const {editData} = await workEditData(
-    Object.assign(work, {
+    {
+      ...work,
       // the attributes are rendered in a different order
       attributes: await lastValueFrom(
         zip(
@@ -93,7 +94,7 @@ export async function importWork(
           toArray()
         )
       ),
-    }),
+    },
     version,
     addWarning
   );

--- a/scripts/acum-work-import/src/work-edit-data.ts
+++ b/scripts/acum-work-import/src/work-edit-data.ts
@@ -177,7 +177,7 @@ export async function workEditData(
             })()
           )
         : originalEditData.languages,
-      iswcs: mergeArrays(originalEditData.iswcs, (await workISWCs(acumWorkId)) ?? []),
+      iswcs: mergeArrays(originalEditData.iswcs, (await workISWCs(track)) ?? []),
       // remove older longer ACUM ID attributes
       attributes: [
         ...originalEditData.attributes.filter(

--- a/scripts/acum-work-import/src/works.ts
+++ b/scripts/acum-work-import/src/works.ts
@@ -22,7 +22,7 @@ const workCache = new Map<string, WorkT>();
 
 export async function findWork(track: WorkBean) {
   const workGid = await (async () => {
-    for (const iswc of await workISWCs(workId(track))) {
+    for (const iswc of await workISWCs(track)) {
       const byIswc = await tryFetchJSON<IswcLookupResultsT>(`/ws/2/iswc/${formatISWC(iswc)}?fmt=json`);
       if (byIswc && byIswc['work-count'] > 0) {
         return byIswc.works[0]!.id;
@@ -35,10 +35,7 @@ export async function findWork(track: WorkBean) {
         from(byName.works).pipe(
           mergeMap(async work => await fetchJSON<WorkLookupResultT>(`/ws/2/work/${work.id}`)),
           filter(
-            work =>
-              work.attributes.find(
-                attr => attr.type === 'ACUM ID' && (attr.value === track.workId || attr.value === track.fullWorkId)
-              ) !== undefined
+            work => work.attributes.find(attr => attr.type === 'ACUM ID' && attr.value === workId(track)) !== undefined
           ),
           defaultIfEmpty(undefined)
         )

--- a/scripts/acum-work-import/tests/work-editor.spec.ts
+++ b/scripts/acum-work-import/tests/work-editor.spec.ts
@@ -322,4 +322,61 @@ test.describe('work editor @allow_fail', () => {
 
     await page.unrouteAll();
   });
+
+  test('can import translated work', async ({page, userscriptPage}) => {
+    // turn off existing work search
+    await userscriptPage.setLocalStorage('searchWorks', 'false');
+
+    await userscriptPage.goto('/work/create');
+
+    // spell: disable
+    const work = {
+      title: 'מגדל השירים',
+      disambiguation: '',
+      workId: '1129800',
+      'type-id': '17',
+      iswcs: [],
+      languages: ['167'],
+      attributes: [
+        {
+          type: 'ACUM ID',
+          value: '2023875005',
+          'type-id': '141',
+        },
+      ],
+      lyricist: 'Leonard Cohen',
+      composer: 'Leonard Cohen',
+      translator: 'אריאל הורוביץ',
+    } as const;
+    // spell: enable
+
+    const workUrl = `https://nocs.acum.org.il/acumsitesearchdb/work?workid=${work.workId}&versionid=${work.attributes[0].value}`;
+    const input = page.getByPlaceholder('Work ID or URL');
+    await input.fill(workUrl);
+    await expect(input).toHaveValue(work.attributes[0].value);
+
+    const importButton = page.getByRole('button', {name: 'Import work from ACUM'});
+    await importButton.click();
+
+    const name = page.getByRole('textbox', {name: 'Name'});
+    await expect(name).toHaveValue(work.title);
+
+    const typeText = await selectBoxText(page.getByRole('combobox', {name: 'Type'}));
+    expect(typeText).toBe('Song');
+
+    const language = page.locator('[id="id-edit-work.languages.0"]');
+    await expect(language).toHaveValue(work.languages[0]);
+
+    const attributeType = await selectBoxText(page.locator('select[name="edit-work.attributes.0.type_id"]'));
+    expect(attributeType).toMatch(new RegExp(`\\s+${work.attributes[0].type}`));
+
+    const attributeValue = page.locator('input[name="edit-work.attributes.0.value"]');
+    await expect(attributeValue).toHaveValue(work.attributes[0].value);
+
+    for (const role of ['composer', 'lyricist', 'translator'] as const) {
+      const roleRow = page.getByRole('row', {name: role});
+      const links = roleRow.getByRole('link');
+      await expect(links).toHaveText(work[role]);
+    }
+  });
 });


### PR DESCRIPTION
Implement the use of version numbers to identify specific translations in the ACUM ID. Update related functions to ensure only artists specific to the translation are linked. Adjust tests to verify the import functionality for translated works.

Fixes #163