### PR TITLE
Monitor HAR recordings with failure allowance

### DIFF
--- a/.github/workflows/update-har.yml
+++ b/.github/workflows/update-har.yml
@@ -34,8 +34,17 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
 
-      - name: Refresh HAR recordings
-        run: yarn record:har
+      - name: Refresh HAR recordings (non-tagged)
+        run: yarn record:har -- --pass-with-no-tests --grep-invert '@allow_har_failure'
+        env:
+          MB_USERNAME: ${{ secrets.MB_USERNAME }}
+          MB_PASSWORD: ${{ secrets.MB_PASSWORD }}
+          # https://github.com/nodejs/node/issues/59364
+          NODE_OPTIONS: --no-experimental-strip-types
+
+      - name: Refresh HAR recordings (allow_har_failure)
+        continue-on-error: true
+        run: yarn record:har -- --pass-with-no-tests --grep '@allow_har_failure'
         env:
           MB_USERNAME: ${{ secrets.MB_USERNAME }}
           MB_PASSWORD: ${{ secrets.MB_PASSWORD }}

--- a/.github/workflows/update-har.yml
+++ b/.github/workflows/update-har.yml
@@ -1,13 +1,19 @@
-name: Update HAR Recordings
+name: Monitor HAR Recordings
 
 on:
   schedule:
     - cron: "0 2 * * 1"
   workflow_dispatch:
+    inputs:
+      force_non_tagged_failure:
+        description: "Force non-tagged refresh failure for monitoring verification"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  issues: write
 
 jobs:
   update-har:
@@ -34,8 +40,16 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
 
-      - name: Refresh HAR recordings (non-tagged)
-        run: yarn record:har -- --pass-with-no-tests --grep-invert '@allow_har_failure'
+      - name: Refresh HAR recordings
+        id: refresh-non-tagged
+        shell: bash
+        run: |
+          set -euo pipefail
+          yarn record:har -- --pass-with-no-tests --grep-invert '@allow_har_failure'
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.force_non_tagged_failure }}" == "true" ]]; then
+            echo "Forcing non-tagged refresh failure for monitoring verification after tests completed"
+            exit 1
+          fi
         env:
           MB_USERNAME: ${{ secrets.MB_USERNAME }}
           MB_PASSWORD: ${{ secrets.MB_PASSWORD }}
@@ -43,6 +57,7 @@ jobs:
           NODE_OPTIONS: --no-experimental-strip-types
 
       - name: Refresh HAR recordings (allow_har_failure)
+        id: refresh-allow-har-failure
         continue-on-error: true
         run: yarn record:har -- --pass-with-no-tests --grep '@allow_har_failure'
         env:
@@ -50,26 +65,45 @@ jobs:
           MB_PASSWORD: ${{ secrets.MB_PASSWORD }}
           # https://github.com/nodejs/node/issues/59364
           NODE_OPTIONS: --no-experimental-strip-types
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug == '1' }}
+        uses: mxschmitt/action-tmate@v3
 
       - name: Detect HAR changes
         id: har-changes
         shell: bash
         run: |
           set -euo pipefail
-          if git status --porcelain | grep -E 'tests/fixtures/har/.*\.har$' >/dev/null; then
+          if git status --porcelain | grep -E 'scripts/.*/tests/fixtures/har/' >/dev/null; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create PR with refreshed HARs
-        if: steps.har-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+      - name: Upload monitoring artifacts
+        id: upload-monitoring-artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          commit-message: "chore(test): refresh HAR recordings"
-          title: "chore(test): refresh HAR recordings"
-          body: |
-            Automated HAR refresh from scheduled live-site test run.
-          branch: chore/update-har-recordings
-          delete-branch: true
-          labels: automated
+          name: har-monitoring-artifacts
+          path: |
+            scripts/*/tests/fixtures/har/
+            scripts/*/playwright-report/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Create or update monitoring issue
+        if: ${{ failure() && steps.refresh-non-tagged.outcome == 'failure' }}
+        uses: benlei/create-issue-templateless@v1
+        with:
+          title: "HAR monitoring: non-tagged failures"
+          update-option: upsert
+          fields: |
+            Summary, Scheduled HAR monitoring detected failures in non-tagged tests.
+            Workflow run, "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            Artifacts, "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-monitoring-artifacts.outputs.artifact-id }}"
+            Run attempt, "${{ github.run_attempt }}"
+            Non-tagged refresh outcome, "${{ steps.refresh-non-tagged.outcome }}"
+            allow_har_failure refresh outcome, "${{ steps.refresh-allow-har-failure.outcome }}"
+            HAR fixture changes detected, "${{ steps.har-changes.outputs.has_changes }}"
+            Note, This issue is intentionally non-blocking for CI replay checks.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@commitlint/config-conventional": "^19.4.1",
     "@commitlint/config-workspace-scopes": "^20.2.0",
     "@eslint/js": "^9.14.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^22.9.0",
@@ -88,7 +88,7 @@
     "fetch-retry": "^6.0.0",
     "p-queue": "^8.1.0",
     "dedent": "^1.7.0",
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.60.0"
   },
   "lint-staged": {
     "src/**": [

--- a/scripts/setlistfm-musicbrainz-import/tests/event.spec.ts
+++ b/scripts/setlistfm-musicbrainz-import/tests/event.spec.ts
@@ -2,7 +2,7 @@ import {test} from '#tests/fixtures/setlistfm-test.ts';
 import {expect} from '@playwright/test';
 import dedent from 'dedent';
 
-test.describe('event page', () => {
+test.describe('event page', {tag: '@allow_har_failure'}, () => {
   test('existing event', async ({page, setlistfmPage, userscriptPage, baseURL}) => {
     await setlistfmPage.goto('/setlist/elton-john/2022/enterprise-center-st-louis-mo-4389530f.html');
 

--- a/scripts/setlistfm-musicbrainz-import/tests/place.spec.ts
+++ b/scripts/setlistfm-musicbrainz-import/tests/place.spec.ts
@@ -1,7 +1,7 @@
 import {test} from '#tests/fixtures/setlistfm-test.ts';
 import {expect} from '@playwright/test';
 
-test.describe('place page', () => {
+test.describe('place page', {tag: '@allow_har_failure'}, () => {
   test('existing place', async ({page, setlistfmPage, userscriptPage, baseURL}) => {
     await setlistfmPage.goto('/venue/whisky-a-go-go-west-hollywood-ca-usa-5bd66bd4.html');
 

--- a/scripts/setlistfm-musicbrainz-import/tests/settings.spec.ts
+++ b/scripts/setlistfm-musicbrainz-import/tests/settings.spec.ts
@@ -1,6 +1,6 @@
 import {test} from '#tests/fixtures/setlistfm-test.ts';
 
-test('setlistfm settings dialog', async ({setlistfmPage, userscriptPage}) => {
+test('setlistfm settings dialog', {tag: '@allow_har_failure'}, async ({setlistfmPage, userscriptPage}) => {
   await setlistfmPage.goto('/venue/whisky-a-go-go-west-hollywood-ca-usa-5bd66bd4.html');
   await userscriptPage.testSettings([
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,7 +1206,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^19.4.1"
     "@commitlint/config-workspace-scopes": "npm:^20.2.0"
     "@eslint/js": "npm:^9.14.0"
-    "@playwright/test": "npm:^1.59.1"
+    "@playwright/test": "npm:^1.60.0"
     "@semantic-release/changelog": "npm:^6.0.3"
     "@semantic-release/git": "npm:^10.0.1"
     "@types/node": "npm:^22.9.0"
@@ -2543,14 +2543,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.59.1":
-  version: 1.59.1
-  resolution: "@playwright/test@npm:1.59.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    playwright: "npm:1.59.1"
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10c0/8c2d94a860d3c254a0b114df2f888ad0a0e9310f45b6059bd5d4da196d965cadf6922267cef0881cfa9784d4bef6d78363d2c2d94caa64be67ff644c41162137
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
   languageName: node
   linkType: hard
 
@@ -8975,27 +8975,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright-core@npm:1.59.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/d41a74d9681ce3beb3d5239e9ed577710b4ad099a6ca2476219c6599d51e9cb4b80bd72ed82c528da6a5d929c18ae3b872cf02bb83f78fa1c2cb9199c501abee
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
   languageName: node
   linkType: hard
 
-"playwright@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright@npm:1.59.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.59.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/dfe38396e616e5c4f98825ce90037bb96e477c5a2bd9258a24854f8ce72a8a41427b19098863866f85aa0216e70287dd537c4438d761aca93995e31ae099c533
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Enhance the HAR recording workflow to allow failures for specific tests when monitoring. Update the workflow to create or update monitoring issues based on non-tagged test failures. Adjust test descriptions to indicate allowance for HAR failures.