### PR TITLE
Add VSCode task for Chrome debugging and enhance acum page functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ playwright-report/
 blob-report/
 playwright/.cache/
 .playwright-mcp/
+.vscode/chrome-user-data/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -13,7 +13,8 @@
     "LICENSE.md",
     "scripts/_template/**",
     "**/playwright-report/**",
-    "**/test-results/**"
+    "**/test-results/**",
+    ".vscode/chrome-user-data/**"
   ],
   "customRules": [
     "markdownlint-rule-relative-links"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
       "request": "launch",
       "name": "Userscript",
       "url": "${input:debug-url}",
+      "userDataDir": "${workspaceFolder}/.vscode/chrome-user-data",
       "pathMapping": {
         "/src": "${workspaceFolder}/scripts/${input:workspace}/src",
       },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,6 +53,14 @@
 			"problemMatcher": []
 		},
 		{
+			"label": "chrome: launch debug profile",
+			"type": "shell",
+			"problemMatcher": [],
+			"windows": {
+				"command": "start chrome -ArgumentList --user-data-dir=${workspaceFolder}/.vscode/chrome-user-data,${input:debug-url}",
+			}
+		},
+		{
 			"type": "npm",
 			"script": "lint",
 			"problemMatcher": [],
@@ -114,6 +122,15 @@
 				"taskId": "debug-url",
 				"rememberPrevious": true,
 			}
+		},
+		{
+			"id": "debug-url",
+			"type": "command",
+			"command": "shellCommand.execute",
+			"args": {
+				"command": "echo ${taskId:debug-url}",
+				"useSingleResult": true,
+			},
 		},
 	]
 }

--- a/scripts/acum-work-import/vite.config.ts
+++ b/scripts/acum-work-import/vite.config.ts
@@ -6,9 +6,7 @@ export default defineConfig('acum-work-import', {
   version: '1.21.0',
   icon: 'https://nocs.acum.org.il/acumsitesearchdb/resources/images/faviconSite.svg',
   match: [
-    'http*://nocs.acum.org.il/acumsitesearchdb/album*',
-    'http*://nocs.acum.org.il/acumsitesearchdb/work*',
-    'http*://nocs.acum.org.il/acumsitesearchdb/version*',
+    'http*://nocs.acum.org.il/acumsitesearchdb/*',
     'http*://*.musicbrainz.org/release/*/edit-relationships',
     'http*://*.musicbrainz.org/release/*/edit-relationships?*',
     'http*://*.musicbrainz.org/work/*/edit',


### PR DESCRIPTION
Introduce a VSCode task to launch Chrome with a debug profile, facilitating debugging for sites like acum.org.il. Update the acum-work-import configuration to ensure functionality across all acum pages, preventing the button from disappearing on entity pages without a reload.