### PR TITLE
Fix post relationships syntax in event forms

### DIFF
--- a/lib/musicbrainz-ext/src/event-form.ts
+++ b/lib/musicbrainz-ext/src/event-form.ts
@@ -75,10 +75,12 @@ export class EventForm {
 
   relationship(
     index: number,
-    relationship: {type: string | number; target: string; direction?: string; targetCredit?: string}
+    relationship: {type: string | number; target: string; direction?: string; targetCredit?: string},
+    options?: {postSyntax: boolean}
   ): this {
-    const base = `rels.${index}`;
-    this.searchParams.append(`${base}.type`, String(relationship.type));
+    const {postSyntax = false} = options ?? {};
+    const base = `${postSyntax ? 'edit-event.rel' : `rels`}.${index}`;
+    this.searchParams.append(`${base}.${postSyntax ? 'link_type_id' : 'type'}`, String(relationship.type));
     this.searchParams.append(`${base}.target`, relationship.target);
     // event part-of rel direction is not seeded
     // https://tickets.metabrainz.org/browse/MBS-14299
@@ -90,10 +92,12 @@ export class EventForm {
   relationshipAttribute(
     relationshipIndex: number,
     attributeIndex: number,
-    attribute: {type: string | number; textValue?: string}
+    attribute: {type: string | number; textValue?: string},
+    options?: {postSyntax: boolean}
   ): this {
-    const base = `rels.${relationshipIndex}.attributes.${attributeIndex}`;
-    this.searchParams.append(`${base}.type`, String(attribute.type));
+    const {postSyntax = false} = options ?? {};
+    const base = `${postSyntax ? 'edit-event.rel' : 'rels'}.${relationshipIndex}.attributes.${attributeIndex}`;
+    this.searchParams.append(`${base}.${postSyntax ? 'type.gid' : 'type'}`, String(attribute.type));
     appendIfValue(this.searchParams, `${base}.text_value`, attribute.textValue);
     return this;
   }

--- a/scripts/scaffold-festival-days/src/api.ts
+++ b/scripts/scaffold-festival-days/src/api.ts
@@ -155,20 +155,32 @@ export async function createSubEvent(
   let relationshipIndex = 0;
 
   if (parentGid) {
-    formData = formData.relationship(relationshipIndex, {
-      type: EVENT_PART_OF_RELATIONSHIP_TYPE_ID,
-      target: parentGid,
-      direction: 'backward',
-    });
+    formData = formData.relationship(
+      relationshipIndex,
+      {
+        type: EVENT_PART_OF_RELATIONSHIP_TYPE_ID,
+        target: parentGid,
+        direction: 'backward',
+      },
+      {
+        postSyntax: !seedOnly,
+      }
+    );
     relationshipIndex++;
   }
 
   if (place) {
-    formData = formData.relationship(relationshipIndex, {
-      type: EVENT_HELD_AT_RELATIONSHIP_TYPE_ID,
-      target: place.gid,
-      targetCredit: place.creditName,
-    });
+    formData = formData.relationship(
+      relationshipIndex,
+      {
+        type: EVENT_HELD_AT_RELATIONSHIP_TYPE_ID,
+        target: place.gid,
+        targetCredit: place.creditName,
+      },
+      {
+        postSyntax: !seedOnly,
+      }
+    );
     relationshipIndex++;
   }
 

--- a/scripts/scaffold-festival-days/tests/scaffold.spec.ts
+++ b/scripts/scaffold-festival-days/tests/scaffold.spec.ts
@@ -19,6 +19,7 @@ type ScaffoldRouteState = {
 };
 
 type TestEventDate = {year: string; month: string; day: string};
+type EventCreateMode = 'seed' | 'post';
 
 function makeFakeGid(counter: number) {
   return `00000000-0000-4000-8000-${String(counter).padStart(12, '0')}`;
@@ -79,27 +80,40 @@ async function setupScaffoldRoutes(params: {
   const createEventEditNotes: string[] = [];
   let gidCounter = 1;
 
-  const recordCreatedEvent = (postData: {[k: string]: unknown}): null | string => {
+  const recordCreatedEvent = (postData: {[k: string]: unknown}, mode: EventCreateMode): null | string => {
     const name = String(postData['edit-event.name']);
 
     createEventEditNotes.push(String(postData['edit-event.edit_note'] ?? ''));
     const gid = makeFakeGid(gidCounter);
     gidCounter += 1;
 
-    const partOfRelIndex = Object.entries(postData)
-      .find(([key, value]) => key.match(/rels\.\d+\.type/) && value === `${EVENT_PART_OF_RELATIONSHIP_TYPE_ID}`)?.[0]
-      ?.replace(/rels\.(\d+)\.type/, '$1');
-    const parentId = partOfRelIndex ? String(postData[`rels.${partOfRelIndex}.target`] ?? '') || null : null;
+    const relationshipBase = mode === 'seed' ? 'rels' : 'edit-event.rel';
+    const relationshipTypeKey = mode === 'seed' ? 'type' : 'link_type_id';
 
-    const placeRelIndex = Object.entries(postData)
-      .find(([key, value]) => key.match(/rels\.\d+\.type/) && value === `${EVENT_HELD_AT_RELATIONSHIP_TYPE_ID}`)?.[0]
-      ?.replace(/rels\.(\d+)\.type/, '$1');
+    const findRelationshipIndex = (typeId: number) => {
+      const expectedTypeId = String(typeId);
+
+      return Object.entries(postData)
+        .find(
+          ([key, value]) =>
+            key.match(new RegExp(`${relationshipBase.replace('.', '\\.')}\\.\\d+\\.${relationshipTypeKey}`)) &&
+            value === expectedTypeId
+        )?.[0]
+        ?.match(new RegExp(`${relationshipBase.replace('.', '\\.')}\\.(\\d+)\\.${relationshipTypeKey}`))?.[1];
+    };
+
+    const partOfRelIndex = findRelationshipIndex(EVENT_PART_OF_RELATIONSHIP_TYPE_ID);
+    const parentId = partOfRelIndex
+      ? String(postData[`${relationshipBase}.${partOfRelIndex}.target`] ?? '') || null
+      : null;
+
+    const placeRelIndex = findRelationshipIndex(EVENT_HELD_AT_RELATIONSHIP_TYPE_ID);
 
     if (placeRelIndex) {
       createdEvents.push({
         name,
-        placeId: String(postData[`rels.${placeRelIndex}.target`]),
-        placeCreditName: String(postData[`rels.${placeRelIndex}.target_credit`]),
+        placeId: String(postData[`${relationshipBase}.${placeRelIndex}.target`] ?? ''),
+        placeCreditName: String(postData[`${relationshipBase}.${placeRelIndex}.target_credit`] ?? ''),
         parentId,
       });
     } else {
@@ -118,7 +132,7 @@ async function setupScaffoldRoutes(params: {
       }
 
       const postData = Object.fromEntries(openedUrl.searchParams.entries()) as {[k: string]: unknown};
-      recordCreatedEvent(postData);
+      recordCreatedEvent(postData, 'seed');
     }
   };
 
@@ -161,7 +175,7 @@ async function setupScaffoldRoutes(params: {
 
   const unrouteEventCreate = await userscriptPage.route('**/event/create', async (route, request) => {
     const postData = await userscriptPage.postDataJSON(request);
-    const gid = recordCreatedEvent(postData) ?? makeFakeGid(gidCounter);
+    const gid = recordCreatedEvent(postData, 'post') ?? makeFakeGid(gidCounter);
 
     await route.fulfill({json: {mbid: gid}});
   });


### PR DESCRIPTION
Update the relationship handling in event forms to support a new syntax for post relationships, improving the clarity and functionality of the code. This change addresses issues with relationship data handling in the scaffold.

Related to #201